### PR TITLE
Remove FUN from whitelist

### DIFF
--- a/src/store/blockchain/tokens/whitelist/mainnet.json
+++ b/src/store/blockchain/tokens/whitelist/mainnet.json
@@ -74,11 +74,6 @@
   "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
   "decimals": 18
 }, {
-  "symbol": "FUN",
-  "name": "FunFair",
-  "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
-  "decimals": 8
-}, {
   "symbol": "BAT",
   "name": "Basic Attention Token",
   "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",


### PR DESCRIPTION
FUN token doesn't work properly because it has 8 digits.