### PR TITLE
update OCEAN contract address

### DIFF
--- a/src/store/blockchain/tokens/whitelist/mainnet.json
+++ b/src/store/blockchain/tokens/whitelist/mainnet.json
@@ -86,7 +86,7 @@
   {
     "symbol": "OCEAN",
     "name": "Ocean Token",
-    "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
+    "address": "0x967da4048cD07aB37855c090aAF366e4ce1b9F48",
     "decimals": 18
   },
   {

--- a/src/store/blockchain/tokens/whitelist/mainnet.json
+++ b/src/store/blockchain/tokens/whitelist/mainnet.json
@@ -85,8 +85,8 @@
   },
   {
     "symbol": "OCEAN",
-    "name": "OceanToken",
-    "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
+    "name": "Ocean Token",
+    "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
     "decimals": 18
   },
   {


### PR DESCRIPTION
Hi there! We [moved to a new token contract](https://blog.oceanprotocol.com/ocean-token-swap-completed-new-contract-live-f0768423b3e1) and moved all holder balances to a new token contract. This PR adds this new OCEAN.

The old contract for OCEAN (`0x985dd3d42de1e256d09e1c10f112bccb8015ad41`) has been paused indefinitely, and OCEAN will be continued in a new contract with the new contract address (`0x7AFeBBB46fDb47ed17b22ed075Cde2447694fB9e `).

Update: we were forced into [another token hard fork](https://blog.oceanprotocol.com/september-2020-hard-fork-ocean-token-completed-8142059361d7), moving into `0x967da4048cD07aB37855c090aAF366e4ce1b9F48`